### PR TITLE
Data provider enhancement

### DIFF
--- a/api/src/main/java/com/eleks/academy/pharmagator/dataproviders/PharmacyDataProvider.java
+++ b/api/src/main/java/com/eleks/academy/pharmagator/dataproviders/PharmacyDataProvider.java
@@ -11,9 +11,9 @@ import com.eleks.academy.pharmagator.entities.Pharmacy;
  *
  * so we could save data properly in our scheduler.
  *
- * If you're intending to use this approach you have to implement your have to
+ * If you're intending to use this approach you have to implement
  *
- * implement your database persistence logic in {@link com.eleks.academy.pharmagator.scheduler.PharmacyScheduler}
+ * your database persistence logic in {@link com.eleks.academy.pharmagator.scheduler.PharmacyScheduler}
  *
  */
 public interface PharmacyDataProvider extends DataProvider {

--- a/api/src/main/java/com/eleks/academy/pharmagator/dataproviders/PharmacyDataProvider.java
+++ b/api/src/main/java/com/eleks/academy/pharmagator/dataproviders/PharmacyDataProvider.java
@@ -1,0 +1,33 @@
+package com.eleks.academy.pharmagator.dataproviders;
+
+import com.eleks.academy.pharmagator.entities.Pharmacy;
+
+/**
+ * Due to database constraints we can`t save the data,obtained from the data provider
+ *
+ * unless we get a proper instance of Pharmacy.
+ *
+ * The implementations of this interface can return instance of {@link Pharmacy}
+ *
+ * so we could save data properly in our scheduler.
+ *
+ * If you're intending to use this approach you have to implement your have to
+ *
+ * implement your database persistence logic in {@link com.eleks.academy.pharmagator.scheduler.PharmacyScheduler}
+ *
+ */
+public interface PharmacyDataProvider extends DataProvider {
+
+    /**
+     * As long as {@link com.eleks.academy.pharmagator.scheduler.PharmacyScheduler}
+     *
+     * doesn't have any validation logic you have to
+     *
+     * make sure that your implementation of this method returns
+     *
+     * valid {@link Pharmacy} instance which corresponds to your data provider
+     *
+     * @return corresponding {@link Pharmacy} instance
+     */
+    Pharmacy getPharmacy();
+}

--- a/api/src/main/java/com/eleks/academy/pharmagator/dataproviders/dto/ds/FilterRequest.java
+++ b/api/src/main/java/com/eleks/academy/pharmagator/dataproviders/dto/ds/FilterRequest.java
@@ -1,5 +1,6 @@
 package com.eleks.academy.pharmagator.dataproviders.dto.ds;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -7,9 +8,10 @@ import lombok.NoArgsConstructor;
 @Data
 @Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class FilterRequest {
 
-	private Long page;
-	private Long per;
+    private Long page;
+    private Long per;
 
 }

--- a/api/src/main/java/com/eleks/academy/pharmagator/scheduler/PharmacyScheduler.java
+++ b/api/src/main/java/com/eleks/academy/pharmagator/scheduler/PharmacyScheduler.java
@@ -1,0 +1,40 @@
+package com.eleks.academy.pharmagator.scheduler;
+
+import com.eleks.academy.pharmagator.dataproviders.PharmacyDataProvider;
+import com.eleks.academy.pharmagator.dataproviders.dto.MedicineDto;
+import com.eleks.academy.pharmagator.entities.Pharmacy;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+@Component
+@RequiredArgsConstructor
+
+public class PharmacyScheduler {
+
+    private final List<PharmacyDataProvider> dataProvidersList;
+
+    //TODO change fixedDelay if needed
+    @Scheduled(fixedDelay = 1, timeUnit = TimeUnit.MINUTES)
+    public void schedule() {
+
+        dataProvidersList.forEach(dataProvider -> {
+
+            Stream<MedicineDto> medicineDtoStream = dataProvider.loadData();
+
+            Pharmacy pharmacy = dataProvider.getPharmacy();
+
+            medicineDtoStream
+                    .forEach(medicineDto -> storeToDatabase(medicineDto, pharmacy));
+        });
+    }
+
+    private void storeToDatabase(MedicineDto medicineDto, Pharmacy pharmacy) {
+
+        //TODO implement custom logic for saving data to the database
+    }
+}


### PR DESCRIPTION
As long as each implemetation will have it's own logic to obtain pharmacyId I guess it makes sense to move this logic from Scheduler into our DataProvider.
Here,I added PharmacyDataProvider interface which exposes getPharmacy() method and PharmacyScheduler.
The point is to extend the existing code,but not change it(at least for now).
If for some reasons you don't want to use this approach you still can work with common DataProvider and Scheduler.
The point is to make our code more flexible.
Let me know if I'm wrong.