### PR TITLE
Added config to make Jacoco ignore generated code

### DIFF
--- a/api/lombok.config
+++ b/api/lombok.config
@@ -1,1 +1,3 @@
 lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Qualifier
+
+lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
That's a single line pull-request :)

Here I added `lombok.addLombokGeneratedAnnotation = true` in `lombok.config`
According to Lombok documentation this configuration will add `@lombok.Generated` annotation to all generated nodes where possible so Jacoco will ignore that code.

In conclusion we'll have more accurate code coverage measurements.