### PR TITLE
DS_Provider_calls_limit_bug_fix

### DIFF
--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -30,7 +30,7 @@ pharmagator:
       category-path: /cat-prods-by-page
       pharmacy-name: pharmacy-ds
       page-limit: 1
-      products-per-page-limit: 50
+      products-per-page-limit: 10
     pharmacy-anc:
       url: https://anc.ua/productbrowser/v2/ua
       category-fetch-url: /categories


### PR DESCRIPTION
So far we had `products-per-page-limit : 50` and `page-limit : 1`.
I've noticed that this pharmacy has a lot of medicines subcategories and fetches **50 products for each.** 
So, with current settings we fetching too much data(in my case it was about **1245 records**).
I simply changed `products-per-page-limit` to 10. Now the data provider fetches only 280 products. I guess it will be enough.