### PR TITLE
Medicine registry adapter

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     implementation 'com.univocity:univocity-parsers:2.9.1'
     implementation 'com.itextpdf:itextpdf:5.5.13.2'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
+    implementation 'org.jsoup:jsoup:1.14.3'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'

--- a/api/src/main/java/com/eleks/academy/pharmagator/dataproviders/AptslavDataProvider.java
+++ b/api/src/main/java/com/eleks/academy/pharmagator/dataproviders/AptslavDataProvider.java
@@ -70,7 +70,7 @@ public class AptslavDataProvider implements DataProvider {
      */
     private AptslavResponseBody<AptslavMedicineDto> sendGetMedicinesRequest(int step, int skip) {
         return aptslavWebClient.get().uri(uriBuilder -> uriBuilder.path(medicinesFetchUri)
-                        .queryParam("fields", "id,externalId,name,created,manufacturer")
+                        .queryParam("fields", "id,externalId,name,created,manufacturer,registrationNumber")
                         .queryParam("take", step)
                         .queryParam("skip", skip)
                         .queryParam("inStock", true)

--- a/api/src/main/java/com/eleks/academy/pharmagator/dataproviders/dto/MedicineDto.java
+++ b/api/src/main/java/com/eleks/academy/pharmagator/dataproviders/dto/MedicineDto.java
@@ -1,7 +1,10 @@
 package com.eleks.academy.pharmagator.dataproviders.dto;
 
 import com.univocity.parsers.annotations.Parsed;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 
@@ -22,5 +25,7 @@ public class MedicineDto {
 
     @Parsed(field = "pharmacyName")
     private String pharmacyName;
+
+    private String registrationId;
 
 }

--- a/api/src/main/java/com/eleks/academy/pharmagator/dataproviders/dto/aptslav/AptslavMedicineDto.java
+++ b/api/src/main/java/com/eleks/academy/pharmagator/dataproviders/dto/aptslav/AptslavMedicineDto.java
@@ -23,4 +23,6 @@ public class AptslavMedicineDto {
 
     private Instant created;
 
+    private String registrationNumber;
+
 }

--- a/api/src/main/java/com/eleks/academy/pharmagator/dataproviders/dto/aptslav/converters/ApiMedicineDtoConverter.java
+++ b/api/src/main/java/com/eleks/academy/pharmagator/dataproviders/dto/aptslav/converters/ApiMedicineDtoConverter.java
@@ -24,11 +24,14 @@ public class ApiMedicineDtoConverter implements ApiDtoConverter<AptslavMedicineD
 
         long externalId = apiDto.getId();
 
+        String registrationId = apiDto.getRegistrationNumber();
+
         return MedicineDto.builder()
                 .externalId(String.valueOf(externalId))
                 .title(title)
                 .price(aptslavPriceDto.getMin())
                 .pharmacyName(pharmacyTitle)
+                .registrationId(registrationId)
                 .build();
     }
 

--- a/api/src/main/java/com/eleks/academy/pharmagator/dataproviders/registry/EmptyResultSetException.java
+++ b/api/src/main/java/com/eleks/academy/pharmagator/dataproviders/registry/EmptyResultSetException.java
@@ -1,0 +1,13 @@
+package com.eleks.academy.pharmagator.dataproviders.registry;
+
+public class EmptyResultSetException extends RuntimeException {
+
+    public EmptyResultSetException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public EmptyResultSetException(String message) {
+        super(message);
+    }
+
+}

--- a/api/src/main/java/com/eleks/academy/pharmagator/dataproviders/registry/IMedicineRegistryProvider.java
+++ b/api/src/main/java/com/eleks/academy/pharmagator/dataproviders/registry/IMedicineRegistryProvider.java
@@ -1,0 +1,9 @@
+package com.eleks.academy.pharmagator.dataproviders.registry;
+
+import java.util.stream.Stream;
+
+public interface IMedicineRegistryProvider {
+
+    Stream<MedicineRegistryRecordDto> fetchRecordsByRegistrationId(String registrationId);
+
+}

--- a/api/src/main/java/com/eleks/academy/pharmagator/dataproviders/registry/MedicineRegistryProvider.java
+++ b/api/src/main/java/com/eleks/academy/pharmagator/dataproviders/registry/MedicineRegistryProvider.java
@@ -1,0 +1,49 @@
+package com.eleks.academy.pharmagator.dataproviders.registry;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+import org.jsoup.select.Evaluator;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MedicineRegistryProvider implements IMedicineRegistryProvider {
+
+    private final ResultTableParser tableParser;
+
+    @Value("${pharmagator.drlz-registry.medicine-fetch-url}")
+    private String baseUrl;
+
+    @Override
+    public Stream<MedicineRegistryRecordDto> fetchRecordsByRegistrationId(String registrationId) {
+        String url = baseUrl + "&rs=" + registrationId;
+
+        try {
+            Document document = Jsoup.connect(url).get();
+
+            Elements tableRows = getResultTableRows(document);
+
+            return tableParser.parse(tableRows);
+        } catch (IOException e) {
+            log.error(e.getMessage(), e.getCause());
+
+            return Stream.empty();
+        }
+    }
+
+    private Elements getResultTableRows(Document document) {
+        return document.select(new Evaluator.AttributeWithValue("bordercolor", "#DDDDDD"))
+                .get(0)
+                .children()
+                .select("tr[valign=top]");
+    }
+
+}

--- a/api/src/main/java/com/eleks/academy/pharmagator/dataproviders/registry/MedicineRegistryRecordDto.java
+++ b/api/src/main/java/com/eleks/academy/pharmagator/dataproviders/registry/MedicineRegistryRecordDto.java
@@ -1,0 +1,37 @@
+package com.eleks.academy.pharmagator.dataproviders.registry;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MedicineRegistryRecordDto {
+
+    private String registrationId;
+
+    private String title;
+
+    private String dosageForm;
+
+    private String manufacturer;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MedicineRegistryRecordDto that = (MedicineRegistryRecordDto) o;
+        return Objects.equals(registrationId, that.registrationId) && Objects.equals(title, that.title);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(registrationId, title);
+    }
+
+}

--- a/api/src/main/java/com/eleks/academy/pharmagator/dataproviders/registry/ResultTableParser.java
+++ b/api/src/main/java/com/eleks/academy/pharmagator/dataproviders/registry/ResultTableParser.java
@@ -1,0 +1,57 @@
+package com.eleks.academy.pharmagator.dataproviders.registry;
+
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Component;
+
+import java.util.stream.Stream;
+
+@Component
+class ResultTableParser {
+
+    public Stream<MedicineRegistryRecordDto> parse(Elements tableRowElements) {
+        return tableRowElements.stream().map(this::getResultFromSingleRow);
+    }
+
+    private MedicineRegistryRecordDto getResultFromSingleRow(Element tableRowElement) {
+        String title = extractTitle(tableRowElement);
+
+        String manufacturer = extractManufacturer(tableRowElement);
+
+        String dosageForm = extractDosageForm(tableRowElement);
+
+        String registryId = extractRegistryId(tableRowElement);
+
+        return MedicineRegistryRecordDto.builder()
+                .registrationId(registryId)
+                .dosageForm(dosageForm)
+                .manufacturer(manufacturer)
+                .title(title)
+                .build();
+    }
+
+    private String extractRegistryId(Element tableRowElement) {
+        Element registryIdTableData = tableRowElement.child(0);
+
+        return registryIdTableData.select("a").get(0).ownText();
+    }
+
+    private String extractTitle(Element tableRowElement) {
+        Element titleTableData = tableRowElement.child(2);
+
+        return titleTableData.ownText().replace("®", "");
+    }
+
+    private String extractDosageForm(Element tableRowElement) {
+        Element titleTableData = tableRowElement.child(2);
+
+        return titleTableData.select("span").get(0).ownText();
+    }
+
+    private String extractManufacturer(Element tableRowElement) {
+        Element manufacturerTableData = tableRowElement.child(4);
+
+        return manufacturerTableData.ownText();
+    }
+
+}

--- a/api/src/main/resources/application.yaml
+++ b/api/src/main/resources/application.yaml
@@ -18,7 +18,7 @@ pharmagator:
   data-providers:
     pharmacy-slavutych:
       pharmacy-name: pharmacy-slavutych
-      api-calls-limit: 3
+      api-calls-limit: 1
       base-url: https://aptslav.com.ua:3000/api/v1
       categories-url: /categories
       medicines-uri: /categories/87/products
@@ -50,3 +50,5 @@ pharmagator:
       medicament-category-id: !!str 4628712
       pharmacy-name: pharmacy-rozetka
       page-limit: 5
+  drlz-registry:
+    medicine-fetch-url: http://drlz.com.ua/ibp/ddsite.nsf/all/shlist?opendocument&

--- a/api/src/test/java/com/eleks/academy/pharmagator/dataproviders/AptslavDataProviderIT.java
+++ b/api/src/test/java/com/eleks/academy/pharmagator/dataproviders/AptslavDataProviderIT.java
@@ -112,7 +112,7 @@ class AptslavDataProviderIT {
 
         assertTrue(request.getPath().startsWith(BASE_URL));
 
-        assertEquals("id,externalId,name,created,manufacturer", getQueryParameter(request, "fields"));
+        assertEquals("id,externalId,name,created,manufacturer,registrationNumber", getQueryParameter(request, "fields"));
 
         assertEquals("100", getQueryParameter(request, "take"));
 
@@ -170,7 +170,7 @@ class AptslavDataProviderIT {
 
         assertTrue(request.getPath().startsWith(BASE_URL));
 
-        assertEquals("id,externalId,name,created,manufacturer", getQueryParameter(request, "fields"));
+        assertEquals("id,externalId,name,created,manufacturer,registrationNumber", getQueryParameter(request, "fields"));
 
         assertEquals("100", getQueryParameter(request, "take"));
 


### PR DESCRIPTION
### Fetch data from medicine registry feature
Since I've created #102 issue I guess I have to provide some solution. 
**Consider this PR just as presentation of my solution for #102 issue.**
I don't think we have to merge it in develop, but I want at least to show it.

This branch contains adapter, which can fetch html page from [http://drlz.com.ua/](url) and find records by registration number.
The registration number is the only option to find the corresponding record in the registry.

`MedicineRegistryProvider` can find records by registration number and wrap it in `MedicineRegistryRecordDto`.
Then we could add some logic to bind data from data providers to records from registry. This could help us to solve data duplication issue.
For example, we could save data from `MedicineRegistryRecordDto` in our data base and create one-to-many relationship with `Price`.
**Unforunatelly, most of our data providers can't provide registration number.**
_I've been trying to solve this in this way:_
- add functionality to find records in registry by title;
- extract dosage form from title, provided by data providers;
- compare string similarity of dosage forms.

Then we can pick the record according to dosage forms similarity.
**I have this solution in separate branch**. 
So, if you want to see that code, let me know and I'll create another PR for that branch.
I've tested it manually and it works most of the time.
In this case, the approximate computation error is about 8-9% ( that means that 8-9% of records can be binded to irrelevant `Price`). 
**I guess it's far from being good, but I couldn't solve this issue in different way.**
